### PR TITLE
Add Clojars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # paraman
 
+[![Clojars Project](https://clojars.org/paraman/latest-version.svg)](http://clojars.org/paraman)
+
 Paraman is a Clojure library for converting Clojure maps into valid HTTP query
 params. It supports arrays and nested objects.
 


### PR DESCRIPTION
I've noticed your lib is on Clojars but there's nowhere on the repo that mentions it's available there. Adding a badge like this would make people who stumbled across your repo (like me) realize it's available there